### PR TITLE
Add OpcodeDUMP_KEYCHAIN class

### DIFF
--- a/needle-agent/needleAgent.xcodeproj/project.pbxproj
+++ b/needle-agent/needleAgent.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		518B75850D12DD83877A4729 /* Pods_needleAgent.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B29985A24DBA4B98B3862D2 /* Pods_needleAgent.framework */; };
+		A65011D21F5C97E70006B9BE /* OpcodeDUMP_KEYCHAIN.m in Sources */ = {isa = PBXBuildFile; fileRef = A65011D11F5C97E70006B9BE /* OpcodeDUMP_KEYCHAIN.m */; };
 		A90CB6A71E6727AA009FEA35 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A90CB6A61E6727A2009FEA35 /* Security.framework */; };
 		A974E21B1E685B4100F60BEF /* OpcodeProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = A93B0E0A1E157C0C002AAAA8 /* OpcodeProtocol.h */; };
 		A974E21E1E68608D00F60BEF /* OpcodeSTOP.m in Sources */ = {isa = PBXBuildFile; fileRef = A974E21D1E68608D00F60BEF /* OpcodeSTOP.m */; };
@@ -36,6 +37,8 @@
 		305856903DDB45CA50AE55C2 /* Pods-needleAgentTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-needleAgentTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-needleAgentTests/Pods-needleAgentTests.release.xcconfig"; sourceTree = "<group>"; };
 		7B014009855E07263F36B776 /* Pods-needleAgentUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-needleAgentUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-needleAgentUITests/Pods-needleAgentUITests.release.xcconfig"; sourceTree = "<group>"; };
 		83310C1D77ED75BE61B9DEB9 /* Pods-needleAgentTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-needleAgentTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-needleAgentTests/Pods-needleAgentTests.debug.xcconfig"; sourceTree = "<group>"; };
+		A65011D11F5C97E70006B9BE /* OpcodeDUMP_KEYCHAIN.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OpcodeDUMP_KEYCHAIN.m; sourceTree = "<group>"; };
+		A65011D31F5C9D600006B9BE /* NeedleAgent.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NeedleAgent.entitlements; sourceTree = "<group>"; };
 		A90CB6A61E6727A2009FEA35 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		A90CB6A91E6728DE009FEA35 /* SecurityFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SecurityFoundation.framework; path = ../../../../../../../../System/Library/Frameworks/SecurityFoundation.framework; sourceTree = "<group>"; };
 		A90CB6AB1E672907009FEA35 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = ../../../../../../../../System/Library/Frameworks/Cocoa.framework; sourceTree = "<group>"; };
@@ -143,6 +146,7 @@
 				A974E21F1E6861A500F60BEF /* OpcodeLIST_APPS.m */,
 				A974E2211E68732600F60BEF /* OpcodeOS_VERSION.m */,
 				A974E21D1E68608D00F60BEF /* OpcodeSTOP.m */,
+				A65011D11F5C97E70006B9BE /* OpcodeDUMP_KEYCHAIN.m */,
 			);
 			name = Opcodes;
 			sourceTree = "<group>";
@@ -179,6 +183,7 @@
 		E9B171F41D548F6A00DB3B60 /* needleAgent */ = {
 			isa = PBXGroup;
 			children = (
+				A65011D31F5C9D600006B9BE /* NeedleAgent.entitlements */,
 				A974E2191E68570D00F60BEF /* Server */,
 				A99C83C91E14528B00D7D13C /* Handlers */,
 				A99C83C81E14515300D7D13C /* Opcodes */,
@@ -350,6 +355,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E9B171FA1D548F6A00DB3B60 /* AppDelegate.m in Sources */,
+				A65011D21F5C97E70006B9BE /* OpcodeDUMP_KEYCHAIN.m in Sources */,
 				E91E39331D66094B00720D62 /* MWRAsyncSocket.m in Sources */,
 				E91B6FD21D587B44000A2939 /* MWRServerViewController.m in Sources */,
 				A9B294F11E9BACD000ACCCA6 /* Utils.m in Sources */,
@@ -480,7 +486,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LIBRARY = "libstdc++";
-				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_ENTITLEMENTS = needleAgent/NeedleAgent.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = U38MMB3T7J;
@@ -505,7 +511,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LIBRARY = "libstdc++";
-				CODE_SIGN_ENTITLEMENTS = "";
+				CODE_SIGN_ENTITLEMENTS = needleAgent/NeedleAgent.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = U38MMB3T7J;

--- a/needle-agent/needleAgent/OpcodeDUMP_KEYCHAIN.m
+++ b/needle-agent/needleAgent/OpcodeDUMP_KEYCHAIN.m
@@ -1,0 +1,320 @@
+//
+//  OpcodeDUMP_KEYCHAIN.m
+//  needleAgent
+//
+
+#import "OpcodeProtocol.h"
+
+@interface OpcodeDUMP_KEYCHAIN : NSObject <OPCODE>
+@end
+
+
+@implementation OpcodeDUMP_KEYCHAIN
+
+
++(NSString *)run:(NSArray *)args
+{
+    NSString *responseString = [NSString stringWithFormat:@"%@%@", [self dumpKeychainItems], COMMAND_OUTPUT_END];
+    
+    return responseString;
+}
+
+
+NSDictionary * parseSecAccessControlObject(id sacObject){
+    
+    // iOS 8 always returns a SecAccessControlRef to an empty dictionary!!
+    // TODO: Test on iOS 9/10 and probably return NSString
+    
+    // Undocumented function
+    // https://opensource.apple.com/source/Security/Security-57031.1.35/Security/sec/Security/SecAccessControl.c
+    /*
+     CFDictionaryRef SecAccessControlGetConstraints(SecAccessControlRef access_control) {
+     return CFDictionaryGetValue(access_control->dict, kAKSKeyAcl);
+     }
+     */
+    
+    CFDictionaryRef SecAccessControlGetConstraints(SecAccessControlRef access_control);
+    // Declare the undocumented function so it can be used
+    
+    CFDictionaryRef sacDict = SecAccessControlGetConstraints((__bridge SecAccessControlRef)(sacObject));
+    // Create dictionary to store SecAccessControl object
+    
+    if (sacDict != NULL){
+        
+        return (__bridge NSDictionary *)(sacDict);
+        
+    } else {
+        
+        return @"No SecAccessControl Constraints";
+    }
+}
+
+
+NSString* convertNSDataToNSString(id value) {
+    
+    // Service and Account values sometimes of type NSData
+    // NSJSONSerialization cannot serialise NSData
+    // Converts only NSData input otherwise returns original value
+    
+    if ([value isKindOfClass:[NSData class]]) {
+        return [[NSString alloc] initWithData:value encoding:NSUTF8StringEncoding];
+    }
+    
+    return value;
+}
+
+
+NSString* encodeDataValue(NSData* dataValue) {
+    
+    // Some Keychain items have no value (null) in the Data field
+    // setObjectForKey: object cannot be nil
+    // If data attempt to encode as UTF8 else encode as BASE64
+    
+    if ([dataValue length] != 0 && dataValue != NULL) {
+        // If some data in data field
+        
+        NSString *formattedUTF8Data = [[NSString alloc] initWithData:dataValue encoding:NSUTF8StringEncoding];
+        // Attempt to encode with UTF8
+        
+        if (formattedUTF8Data == NULL | [formattedUTF8Data length] == 0){
+            // UTF8 Encoding didn't work
+            
+            return [dataValue base64EncodedStringWithOptions:0];
+            // Return the data as a base64 encoded string
+            
+        } else {
+            // UTF8 Encoding did work
+            
+            return formattedUTF8Data;
+            // Return the data as a UTF8 encoded string
+        }
+        
+    } else {
+        
+        //return [[@"null" dataUsingEncoding:NSUTF8StringEncoding] base64EncodedStringWithOptions:0];
+        // Returns " "
+        
+        return @"null";
+        // Returns "null"
+    }
+    
+}
+
+
+NSString *mapkSecAttrAccessibleValues(NSString *pdmn) {
+    
+    // https://opensource.apple.com/source/Security/Security-55471/sec/Security/SecItemConstants.c.auto.html
+    
+    if ([pdmn isEqualToString:@"ck"])
+        return @"kSecAttrAccessibleAfterFirstUnlock";
+    
+    else if ([pdmn isEqualToString:@"cku"])
+        return @"kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly";
+    
+    else if ([pdmn isEqualToString:@"dk"])
+        return @"kSecAttrAccessibleAlways";
+    
+    else if ([pdmn isEqualToString:@"akpu"])
+        return @"kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly";
+    
+    else if ([pdmn isEqualToString:@"dku"])
+        return @"kSecAttrAccessibleAlwaysThisDeviceOnly";
+    
+    else if ([pdmn isEqualToString:@"ak"])
+        return @"kSecAttrAccessibleWhenUnlocked";
+    
+    else if ([pdmn isEqualToString:@"aku"])
+        return @"kSecAttrAccessibleWhenUnlockedThisDeviceOnly";
+    
+    else
+        return @"Unknown kSecAttrAccessible Value";
+    
+}
+
+
+NSData* convertToJSON(NSArray *keychainDictionariesArray) {
+    
+    // Convert array of dictionaries to dictionary of dictionaries
+    // Each dictionary in keychainDictionariesArray is a keychain item
+    // Build keychainItem from dictionaries in keychainDictionariesArray
+    // Do some processing: mapkSecAttrAccessibleValues, convertNSDataToNSString and encodeDataValue
+    // Add each keychainItem to processedKeychainItems then serialise to JSON
+    
+    // JSON Format:
+    /*
+     {
+     "index" : {
+     "Protection" : ""
+     "Account" : ""
+     "Access Control : "
+     "Creation Time" : ""
+     "Entitlement Group" : ""
+     "Service" : ""
+     "Modified Time" : ""
+     "Data" : ""
+     },
+     }
+     */
+    
+    NSMutableDictionary *processedKeychainItems = [[NSMutableDictionary alloc] init];
+    NSDictionary *keychainItemDictionary = [[NSDictionary alloc] init];
+    NSInteger keychainItemIndex = 0;
+    
+    for (keychainItemDictionary in keychainDictionariesArray) {
+        // Build dictionary keychainItem from each dictionary in keychainDictionariesArray
+        
+        NSMutableDictionary *keychainItem = [[NSMutableDictionary alloc] init];
+        // Temp dictionary to hold individual keychain items before being added to processedKeychainItems
+        
+        [keychainItem setObject:mapkSecAttrAccessibleValues([keychainItemDictionary
+                                                             objectForKey:(id)kSecAttrAccessible])
+                         forKey:@"Protection"];
+        
+        [keychainItem setObject:convertNSDataToNSString([keychainItemDictionary
+                                                         objectForKey:(id)kSecAttrAccount])
+                         forKey:@"Account"];
+        
+        [keychainItem setObject:parseSecAccessControlObject([keychainItemDictionary
+                                                             objectForKey:(id) kSecAttrAccessControl])
+                         forKey:@"Access Control"];
+        
+        [keychainItem setObject:[NSString stringWithFormat:@"%@", [keychainItemDictionary
+                                                                   objectForKey:(id)kSecAttrCreationDate]]
+                         forKey:@"Creation Time"];
+        
+        [keychainItem setObject:[NSString stringWithFormat:@"%@", [keychainItemDictionary
+                                                                   objectForKey:(id)kSecAttrAccessGroup]]
+                         forKey:@"Entitlement Group"];
+        
+        [keychainItem setObject:convertNSDataToNSString([keychainItemDictionary
+                                                         objectForKey:(id)kSecAttrService])
+                         forKey:@"Service"];
+        
+        [keychainItem setObject:[NSString stringWithFormat:@"%@", [keychainItemDictionary
+                                                                   objectForKey:(id)kSecAttrModificationDate]]
+                         forKey:@"Modified Time"];
+        
+        [keychainItem setObject:encodeDataValue([keychainItemDictionary
+                                                 objectForKey:(id)kSecValueData])
+                         forKey:@"Data"];
+        
+        
+        [processedKeychainItems setObject:keychainItem
+                                   forKey:[NSString stringWithFormat:@"%li", (long)keychainItemIndex++]];
+        // Add keychainItem dictionary to processedKeychainItems Dictionary
+        
+    }
+    
+    NSError* error = nil;
+    NSData* json = nil;
+    
+    json = [NSJSONSerialization dataWithJSONObject:processedKeychainItems options:NSJSONWritingPrettyPrinted error:&error];
+    // Convert processedKeychainItems dictionary to JSON
+    
+    if (json != nil && error == nil) {
+        // If NSJSONSerialization returns no error and some data
+        return json;
+    }
+    else {
+        // If NSJSONSerialization an error or no data
+        return nil;
+    }
+}
+
+
++ (NSString *)dumpKeychainItems
+{
+    
+    NSMutableDictionary *query = [[NSMutableDictionary alloc] init];
+    // Dictionary that describes SecItemCopyMatching search
+    
+    NSMutableArray *queryResult = [[NSMutableArray alloc] init];
+    // Array for returned Keychain item dictionaries
+    // Each item is returned as a dictionary
+    
+    NSString *eachConstant = [[NSString alloc] init];
+    // Init string to hold accessibility attribute
+    
+    OSStatus status = -1;
+    // Setup OSStatus return code
+    
+    NSArray *kSecAttrAccessibleValues = @[
+                                          (NSString *)kSecAttrAccessibleAfterFirstUnlock,
+                                          (NSString *)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+                                          (NSString *)kSecAttrAccessibleAlways,
+                                          (NSString *)kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly,
+                                          (NSString *)kSecAttrAccessibleAlwaysThisDeviceOnly,
+                                          (NSString *)kSecAttrAccessibleWhenUnlocked,
+                                          (NSString *)kSecAttrAccessibleWhenUnlockedThisDeviceOnly];
+    // Array holding possible kSecAttrAccessible values
+    
+    for (eachConstant in kSecAttrAccessibleValues) {
+        // For each kSecAttrAccessible type create a query requesting
+        // all accessible Keychain items of type kSecClassGenericPassword
+        // Return the attributes and data of each item
+        
+        [query setObject:   (id)kSecClassGenericPassword
+                  forKey:   (id)kSecClass];
+        // Query for  generic password items
+        
+        [query setObject:   eachConstant
+                  forKey:   (id<NSCopying>)(kSecAttrAccessible)];
+        // Accessibility attribute of item
+        
+        [query setObject:   (id)kSecMatchLimitAll
+                  forKey:   (id)kSecMatchLimit];
+        // Maximum number of results to return
+        
+        [query setObject:   (id)kCFBooleanTrue
+                  forKey:   (id)kSecReturnAttributes];
+        // Return unencrypted dictionary (type CFDictionaryRef) of item attributes
+        
+        [query setObject:   (id)kCFBooleanTrue
+                  forKey:   (id)kSecReturnData];
+        // Return a CFDataRef object of item data
+        
+        
+        CFTypeRef results = nil;
+        // Setup object for SecItemCopyMatching to store results
+        
+        status = SecItemCopyMatching((CFDictionaryRef)query, &results);
+        // Search for items matching query
+        
+        if (status == errSecSuccess) {
+            // status = 0 on success
+            
+            [queryResult addObjectsFromArray: (__bridge NSArray *)results];
+            // Add returned data into Dictionary returnedKeyChainItems from results
+            
+        }
+    }
+    
+    
+    if ([queryResult count] != 0) {
+        // If at least one Keychain item found
+        
+        NSData *json = convertToJSON(queryResult);
+        // Convert array of Keychain items to JSON
+        
+        if (json == nil) {
+            // convertToJSON returns nill if NSJSONSerialization
+            // returns an error or produces no data
+            return (@"NSJSONSerialization Error!");
+        }
+        
+        NSString *keychainItemsAsJSONString = [[NSString alloc] initWithData:json encoding:NSUTF8StringEncoding];
+        // Convert json to NSString object
+        
+        return keychainItemsAsJSONString;
+        //  Dictionary return finalKeychainItems array
+        
+    } else {
+        
+        NSString *statusString = [NSString stringWithFormat:@"OSStatus: %i", (int)status];
+        return statusString;
+        // If no data in returnedKeyChainItems return OSStatus code
+    }
+}
+
+
+@end


### PR DESCRIPTION
### Added

Changes proposed in this pull request: 

- Add class `DUMP_KEYCHAIN` which dumps all accessible Keychain items of type `kSecClassGenericPassword`

### Support 

- iOS 8: Yes. 
- iOS 9: Untested
- iOS 10: No, partially tested. 
  - Currently returns error `-25300` `errSecItemNotFound`.

### Function Descriptions

- `dumpKeychainItems`: Creates a query to pass to `SecItemCopyMatching` to fetch all `kSecClassGenericPassword` keychain items.
- `convertNSDataToNSString`: Converts `NSData` objects to `NSString`. Used to normalise Service and Account keychain attributes. 
- `encodeDataValue`: Tries to encode Keychain item data to UTF8 if not encodes as Base64.
- `mapkSecAttrAccessibleValues`: Maps protection domain (`pdmn`) value to keychain accessibility value.
- `parseSecAccessControlObject`: Initial function skeleton. iOS 8 will always return an empty SAC dictionary. Uses undocumented function `SecAccessControlGetConstraints`.
